### PR TITLE
Fix app crash if message does not contain a emoji when using the reply command

### DIFF
--- a/src/utils/emoji-replace.ts
+++ b/src/utils/emoji-replace.ts
@@ -15,7 +15,7 @@ export const emoteGex = /(?<!<)(?<!<a):([A-z0-9-_]+):/g;
  */
 export function replaceEmoji(message: string, emojiManager: GuildEmojiManager): string {
     const emojisFound = message.match(emoteGex);
-    if (emojisFound === undefined) { return message; } // No emoji presents in the string, do nothing
+    if (emojisFound === null) { return message; } // No emoji presents in the string, do nothing
 
     // Find unique emojis to avoid multiple replacements on single emoji
     const uniqueEmoji = emojisFound.filter((elem, pos) => {


### PR DESCRIPTION
- regex match returns null instead of undefined